### PR TITLE
Revanced Extended (DOCKER BUILD METHOD)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get --yes update && \
   rm /app/zulu.deb && \
   apt-get -f install
 
-RUN git clone --depth=1 --no-tags https://github.com/inotia00/rvx-builder
+RUN git clone --no-tags https://github.com/inotia00/rvx-builder
 
 WORKDIR /app/rvx-builder
+
+RUN git checkout revanced-extended
 
 RUN npm install --omit=dev
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ For developers, see [this](https://github.com/inotia00/rvx-builder/blob/revanced
 
 ## How to use (Docker)
 
-Required [docker](https://docs.docker.com/get-docker/) and [docker-compose(for linux cli)](https://docs.docker.com/compose/install/linux/) must be installed
+Required [docker](https://docs.docker.com/get-docker/) and [docker-compose(for linux cli)](https://docs.docker.com/compose/install/linux/) must be installed.
 
-**Note: If using docker desktop docker-compose will be pre-installed**
+**Note: If using Docker Desktop, docker-compose will already be pre-installed.**
 
-Clone the repository and cd into the directory `revanced-builder`
+Clone the repository and cd into the directory `rvx-builder`
+
+**Note: Make sure you are in the `revanced-extended` branch, you can make sure of that by doing a `git checkout revanced-extended` when cloned into `rvx-builder`**
 
 Build using docker-compose
 
@@ -47,7 +49,7 @@ To stop your container
 docker-compose down
 ```
 
-**Note: docker-compose uses docker-compose.yml so make sure you are in the same directory `revanced-builder`**
+**Note: docker-compose uses docker-compose.yml so make sure you are in the same directory `rvx-builder`**
 
 To update to newer version of builder, stop existing container if running and build the image again and start the container again
 
@@ -74,4 +76,4 @@ docker rmi <name_of_the_image> -f
 
 To update to newer version of builder, stop existing container if running and build the image again and start the container again
 
-In both the build a persistent storage is kept so all the build are stored in `rvx-builder/revanced/` 
+In both the builds a persistent storage is kept so all the builds are stored in `rvx-builder/revanced/` 


### PR DESCRIPTION
* Added Note and small changes to Docker instructions to remind of the proper branch (read commit notes).
* Made changes to the Dockerfile so it will actually build and run the RVX-Builder instead of reisxd's Builder (read commit notes).

Tried my best with the research I could do, and I know you're busy with life now, so wish you the best, and of course when you can please do check it out and verify it's all good.

Also maybe it could be a good opportunity to add the Docker method to the official [ReVanced Extended Documentation](https://github.com/inotia00/revanced-documentation)...
This is for me the most guaranteed and reliable way so far. It just requires a bit of set-up...