### PR TITLE
fix: empty the app name if it remains indeterminate

### DIFF
--- a/wsEvents/patchApp.js
+++ b/wsEvents/patchApp.js
@@ -88,10 +88,11 @@ async function reinstallReVanced() {
 
 function outputName() {
   const part1 = 'ReVanced';
-  const appName = global.jarNames.selectedApp.appName;
-  let part2 = appName
+  let part2 = global.jarNames?.selectedApp?.appName
     ? global.jarNames.selectedApp.appName.replace(/[^a-zA-Z0-9\\.\\-]/g, '')
-    : global.jarNames.packageName.replace(/\./g, '');
+    : global?.jarNames?.packageName
+    ? global.jarNames.packageName.replace(/\./g, '')
+    : ''; // make the app name empty if we cannot detect it
 
   // TODO: If the existing input APK is used from revanced/ without downloading, version and arch aren't set
   const part3 = global?.apkInfo?.version ? `v${global.apkInfo.version}` : '';


### PR DESCRIPTION
"Resolves "Revanced Builder Bug In Ubuntu" #615"
*ty shrihanDev*

Merging should at least fix https://github.com/inotia00/rvx-builder/issues/28 for Termux/Node users for the moment until there's an executable hotfix release

@inotia00 Hotfix maybe?