### PR TITLE
Workaround for APKMirror crash (Issue #89)

### DIFF
--- a/wsEvents/getApp.js
+++ b/wsEvents/getApp.js
@@ -16,9 +16,13 @@ async function fetchPackages(packages) {
     }
   );
 
-  const response = await request.json();
-
-  return response.data;
+  try {
+    const response = await request.json();
+    return response.data;
+  } catch (e) {
+    const response = [];
+    return response;
+  }
 }
 /**
  * @param {import('ws').WebSocket} ws


### PR DESCRIPTION
When APKMirror is not reachable due to firewall or provider settings, an error occurs (https://github.com/inotia00/rvx-builder/issues/89):

FetchError: invalid json response body at https://www.apkmirror.com/wp-json/apkm/v1/app_exists/ reason: Unexpected token < in JSON at position 0 at C:\snapshot\rvx-builder\node_modules\node-fetch\lib\index.js:273:32 at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async fetchPackages (C:\snapshot\rvx-builder\wsEvents\getApp.js:19:20) at async getPatches (C:\snapshot\rvx-builder\wsEvents\getApp.js:40:16) at async WebSocket

Added a silent catch to this error so we could continue running builder by uploading an APK file from disk.
Build [v3.9.12-1](https://github.com/Shaarigan/rvx-builder/releases/tag/v3.9.12) tested on Windows 10