### PR TITLE
Add missing libs to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-slim
 WORKDIR /app
 
 RUN apt-get --yes update && \
-  apt-get --yes install git wget java-common libasound2 libxi6 libxtst6 xdg-utils && \
+  apt-get --yes install git wget java-common libasound2 libxi6 libxtst6 xdg-utils libgtk2.0-0 libatk1.0-0 libpango1.0-0 libgdk-pixbuf2.0-0 libcairo2 libgl1-mesa-glx && \
   wget -O /app/zulu.deb https://cdn.azul.com/zulu/bin/zulu17.50.19-ca-fx-jdk17.0.11-linux_amd64.deb && \
   yes | dpkg -i /app/zulu.deb && \
   rm /app/zulu.deb && \


### PR DESCRIPTION
Without these libs zulu-fx complains about them missing on the latest `node:lts-slim@sha256:b5e567dc37677a1485cec21e2f0c0df517c7afe40c1ebc28248c41520c77b3d0`

```
34.38 2024-07-09 14:48:59 (31.5 MB/s) - '/app/zulu.deb' saved [255716660/255716660]
34.38
34.40 Selecting previously unselected package zulu-fx-17.
34.41 (Reading database ... 13295 files and directories currently installed.)
34.41 Preparing to unpack /app/zulu.deb ...
34.41 Unpacking zulu-fx-17 (17.50+19-1) ...
44.09 dpkg: dependency problems prevent configuration of zulu-fx-17:
44.09  zulu-fx-17 depends on libgtk2.0-0; however:
44.09   Package libgtk2.0-0 is not installed.
44.09  zulu-fx-17 depends on libatk1.0-0; however:
44.09   Package libatk1.0-0 is not installed.
44.09  zulu-fx-17 depends on libpango1.0-0; however:
44.09   Package libpango1.0-0 is not installed.
44.09  zulu-fx-17 depends on libgdk-pixbuf2.0-0; however:
44.09   Package libgdk-pixbuf2.0-0 is not installed.
44.09  zulu-fx-17 depends on libcairo2; however:
44.09   Package libcairo2 is not installed.
44.09  zulu-fx-17 depends on libgl1-mesa-glx; however:
44.09   Package libgl1-mesa-glx is not installed.
44.09
44.09 dpkg: error processing package zulu-fx-17 (--install):
44.09  dependency problems - leaving unconfigured
44.10 Errors were encountered while processing:
44.10  zulu-fx-17
```