### PR TITLE
ci: workflow to ping Discord users when rvx-builder is released

### DIFF
--- a/.github/workflows/discord_ping_on_release.yml
+++ b/.github/workflows/discord_ping_on_release.yml
@@ -19,4 +19,4 @@ jobs:
           content: "<@&1271198236350087283>"
           title: "RVX-Builder `${{ github.event.release.tag_name }}` has been released!"
           description: |
-            Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download it and read the changelog.
+            Click [here](${{ github.event.release.html_url }}) to download it and read the changelog.

--- a/.github/workflows/discord_ping_on_release.yml
+++ b/.github/workflows/discord_ping_on_release.yml
@@ -17,6 +17,6 @@ jobs:
           nodetail: true
           notimestamp: true
           content: "<@&1271198236350087283>"
-          title: "RVX-Builder ${{ github.event.release.tag_name }} has been released!"
+          title: "RVX-Builder `${{ github.event.release.tag_name }}` has been released!"
           description: |
-            Download and read the changelog on the [releases page]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}).
+            Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download it and read the changelog.

--- a/.github/workflows/discord_ping_on_release.yml
+++ b/.github/workflows/discord_ping_on_release.yml
@@ -1,0 +1,22 @@
+name: Ping Discord on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: ReVanced Extended
+          color: 0xff5252
+          nodetail: true
+          notimestamp: true
+          content: "<@&1271198236350087283>"
+          title: "RVX-Builder ${{ github.event.release.tag_name }} has been released!"
+          description: |
+            Download and read the changelog on the [releases page]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}).


### PR DESCRIPTION
For more info, refer to https://github.com/inotia00/revanced-patches/pull/72