### PR TITLE
Remove version from compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   rvx-builder:
     container_name: rvx-builder


### PR DESCRIPTION
Version has been deprecated since late 2020 and newer docker version show a warning, so probably good to just get rid of it